### PR TITLE
Fix ANIME data relation card and update versioning configurations

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
    "expo": {
       "name": "Kaiwa",
       "slug": "kaiwa",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "orientation": "portrait",
       "icon": "./assets/images/icon.png",
       "scheme": "kaiwa",
@@ -39,6 +39,12 @@
       "experiments": {
          "typedRoutes": true,
          "reactCompiler": true
+      },
+      "extra": {
+         "router": {},
+         "eas": {
+            "projectId": "2a5e18f1-8566-4020-a59b-50e4efe76001"
+         }
       }
    }
 }

--- a/app.json
+++ b/app.json
@@ -45,6 +45,12 @@
          "eas": {
             "projectId": "2a5e18f1-8566-4020-a59b-50e4efe76001"
          }
+      },
+      "runtimeVersion": {
+         "policy": "appVersion"
+      },
+      "updates": {
+         "url": "https://u.expo.dev/2a5e18f1-8566-4020-a59b-50e4efe76001"
       }
    }
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -4,7 +4,9 @@ import { Image } from "expo-image";
 import { Stack, useRouter, useSegments } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
+import * as Updates from "expo-updates";
 import { useEffect, useState } from "react";
+import { Alert } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
 import { Provider } from "urql";
@@ -165,6 +167,29 @@ export default function RootLayout() {
          router.replace("/(tabs)");
       }
    }, [isLoggedIn, segments, isReady, router]);
+
+   useEffect(() => {
+      async function onFetchUpdateAsync() {
+         try {
+            const update = await Updates.checkForUpdateAsync();
+
+            if (update.isAvailable) {
+               await Updates.fetchUpdateAsync();
+
+               Alert.alert("Update Available", "A new version of Kaiwa is ready. Restart now?", [
+                  { text: "Later" },
+                  { text: "Restart", onPress: () => Updates.reloadAsync() },
+               ]);
+            }
+         } catch (error) {
+            console.warn(`Error fetching update: ${error}`);
+         }
+      }
+
+      if (!__DEV__) {
+         onFetchUpdateAsync();
+      }
+   }, []);
 
    return (
       <GestureHandlerRootView style={{ flex: 1, backgroundColor: "#030014" }}>

--- a/app/anime/[id].tsx
+++ b/app/anime/[id].tsx
@@ -532,7 +532,8 @@ const Anime = () => {
                            <RelationCard
                               id={item?.node?.id ?? 0}
                               relationType={item?.relationType ?? ""}
-                              type={item?.node?.format ?? ""}
+                              type={item?.node?.type ?? ""}
+                              format={item?.node?.format ?? ""}
                               title={
                                  item?.node?.title?.english ??
                                  item?.node?.title?.romaji ??

--- a/app/manga/[id].tsx
+++ b/app/manga/[id].tsx
@@ -150,7 +150,7 @@ const Manga = () => {
 
    if (charactersError) console.error("Error fetching characters data:", charactersError);
 
-   if (error) console.error("Error fetching anime data:", error);
+   if (error) console.error("Error fetching manga data:", error);
 
    if (fetching)
       return (
@@ -456,7 +456,8 @@ const Manga = () => {
                            <RelationCard
                               id={item?.node?.id ?? 0}
                               relationType={item?.relationType ?? ""}
-                              type={item?.node?.format ?? ""}
+                              type={item?.node?.type ?? ""}
+                              format={item?.node?.format ?? ""}
                               title={
                                  item?.node?.title?.english ??
                                  item?.node?.title?.romaji ??

--- a/components/RelationCard.tsx
+++ b/components/RelationCard.tsx
@@ -6,11 +6,12 @@ interface RelationCardProps {
    id: number;
    relationType: string;
    type: string;
+   format: string;
    title: string;
    image: string;
 }
 
-const RelationCard = ({ id, relationType, type, title, image }: RelationCardProps) => {
+const RelationCard = ({ id, relationType, type, format, title, image }: RelationCardProps) => {
    const router = useRouter();
    const imageUri = (image || "").trim();
 
@@ -40,7 +41,7 @@ const RelationCard = ({ id, relationType, type, title, image }: RelationCardProp
             <View className="h-[200] w-[150] rounded-lg bg-slate-800" />
          )}
          <Text className="absolute left-2 top-2 rounded-sm bg-slate-900/70 px-1 text-[11px] font-medium text-white">
-            {type}
+            {format.split("_").join(" ")}
          </Text>
          <View className="flex-1 items-center px-2">
             <Text className="mt-1 text-white" numberOfLines={2}>

--- a/eas.json
+++ b/eas.json
@@ -6,13 +6,22 @@
    "build": {
       "development": {
          "developmentClient": true,
-         "distribution": "internal"
+         "distribution": "internal",
+         "channel": "development"
       },
       "preview": {
-         "distribution": "internal"
+         "distribution": "internal",
+         "channel": "preview",
+         "android": {
+            "buildType": "apk"
+         }
       },
       "production": {
-         "autoIncrement": true
+         "autoIncrement": true,
+         "channel": "production",
+         "android": {
+            "buildType": "apk"
+         }
       }
    },
    "submit": {

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,21 @@
+{
+   "cli": {
+      "version": ">= 18.7.0",
+      "appVersionSource": "remote"
+   },
+   "build": {
+      "development": {
+         "developmentClient": true,
+         "distribution": "internal"
+      },
+      "preview": {
+         "distribution": "internal"
+      },
+      "production": {
+         "autoIncrement": true
+      }
+   },
+   "submit": {
+      "production": {}
+   }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
    "name": "kaiwa",
-   "version": "0.1.0",
+   "version": "0.2.1",
    "lockfileVersion": 3,
    "requires": true,
    "packages": {
       "": {
          "name": "kaiwa",
-         "version": "0.1.0",
+         "version": "0.2.1",
          "dependencies": {
             "@expo/vector-icons": "^15.0.3",
             "@react-native-community/netinfo": "11.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
             "expo-status-bar": "~3.0.9",
             "expo-symbols": "~1.0.8",
             "expo-system-ui": "~6.0.9",
+            "expo-updates": "~29.0.16",
             "expo-web-browser": "~15.0.10",
             "graphql": "^16.13.2",
             "lucide-react-native": "^1.8.0",
@@ -9095,6 +9096,12 @@
             "expo": "*"
          }
       },
+      "node_modules/expo-eas-client": {
+         "version": "1.0.8",
+         "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-1.0.8.tgz",
+         "integrity": "sha512-5or11NJhSeDoHHI6zyvQDW2cz/yFyE+1Cz8NTs5NK8JzC7J0JrkUgptWtxyfB6Xs/21YRNifd3qgbBN3hfKVgA==",
+         "license": "MIT"
+      },
       "node_modules/expo-file-system": {
          "version": "19.0.21",
          "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.21.tgz",
@@ -9515,6 +9522,12 @@
             "react-native": "*"
          }
       },
+      "node_modules/expo-structured-headers": {
+         "version": "5.0.0",
+         "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-5.0.0.tgz",
+         "integrity": "sha512-RmrBtnSphk5REmZGV+lcdgdpxyzio5rJw8CXviHE6qH5pKQQ83fhMEcigvrkBdsn2Efw2EODp4Yxl1/fqMvOZw==",
+         "license": "MIT"
+      },
       "node_modules/expo-symbols": {
          "version": "1.0.8",
          "resolved": "https://registry.npmjs.org/expo-symbols/-/expo-symbols-1.0.8.tgz",
@@ -9548,6 +9561,36 @@
             }
          }
       },
+      "node_modules/expo-updates": {
+         "version": "29.0.16",
+         "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-29.0.16.tgz",
+         "integrity": "sha512-E9/fxRz/Eurtc7hxeI/6ZPyHH3To9Xoccm1kXoICZTRojmuTo+dx0Xv53UHyHn4G5zGMezyaKF2Qtj3AKcT93w==",
+         "license": "MIT",
+         "dependencies": {
+            "@expo/code-signing-certificates": "^0.0.6",
+            "@expo/plist": "^0.4.8",
+            "@expo/spawn-async": "^1.7.2",
+            "arg": "4.1.0",
+            "chalk": "^4.1.2",
+            "debug": "^4.3.4",
+            "expo-eas-client": "~1.0.8",
+            "expo-manifests": "~1.0.10",
+            "expo-structured-headers": "~5.0.0",
+            "expo-updates-interface": "~2.0.0",
+            "getenv": "^2.0.0",
+            "glob": "^13.0.0",
+            "ignore": "^5.3.1",
+            "resolve-from": "^5.0.0"
+         },
+         "bin": {
+            "expo-updates": "bin/cli.js"
+         },
+         "peerDependencies": {
+            "expo": "*",
+            "react": "*",
+            "react-native": "*"
+         }
+      },
       "node_modules/expo-updates-interface": {
          "version": "2.0.0",
          "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-2.0.0.tgz",
@@ -9556,6 +9599,12 @@
          "peerDependencies": {
             "expo": "*"
          }
+      },
+      "node_modules/expo-updates/node_modules/arg": {
+         "version": "4.1.0",
+         "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+         "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
+         "license": "MIT"
       },
       "node_modules/expo-web-browser": {
          "version": "15.0.10",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
    "name": "kaiwa",
    "main": "expo-router/entry",
-   "version": "0.1.0",
+   "version": "0.2.1",
    "scripts": {
       "start": "expo start",
       "android": "expo run:android",
@@ -12,7 +12,8 @@
       "lint": "expo lint",
       "lint:fix": "expo lint --fix",
       "prepare": "husky",
-      "codegen": "graphql-codegen --config codegen.ts"
+      "codegen": "graphql-codegen --config codegen.ts",
+      "eas-build-post-install": "npm run codegen"
    },
    "lint-staged": {
       ".{ts,tsx,js,jsx}": [

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
       "expo-status-bar": "~3.0.9",
       "expo-symbols": "~1.0.8",
       "expo-system-ui": "~6.0.9",
+      "expo-updates": "~29.0.16",
       "expo-web-browser": "~15.0.10",
       "graphql": "^16.13.2",
       "lucide-react-native": "^1.8.0",


### PR DESCRIPTION
This pull request introduces several new features and improvements, focusing on enabling over-the-air (OTA) updates with Expo, enhancing the `RelationCard` component, and updating project configuration for EAS (Expo Application Services) builds. It also includes minor bug fixes and version bumps.

**OTA Updates and EAS Integration:**

* Added `expo-updates` to dependencies and implemented automatic OTA update checking and prompting in `app/_layout.tsx` for production builds. Users are prompted to restart the app when a new update is available. [[1]](diffhunk://#diff-a297596ca5a79abd3db7509592a07106f1c27c02ee55895a4dee8bcce9f7da57R7-R9) [[2]](diffhunk://#diff-a297596ca5a79abd3db7509592a07106f1c27c02ee55895a4dee8bcce9f7da57R171-R193) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R51)
* Updated `app.json` and added a new `eas.json` to configure EAS build profiles, runtime version policy, and update URL for remote OTA updates. [[1]](diffhunk://#diff-96677aa35debfefd031d9d34d9c70369754ee3acb2d9a9d4090e98612efee6f5R42-R53) [[2]](diffhunk://#diff-6a8d51cdb96fc8aad6ee86d457647737bb7f21f1bf6a5c1c2c44bed088cfa8d2R1-R30)

**RelationCard Component Enhancements:**

* Updated `RelationCard` to accept and display a new `format` prop (e.g., "TV", "MANGA") for clearer relation type labeling. Adjusted usage in both anime and manga detail screens to provide both `type` and `format`. [[1]](diffhunk://#diff-f6787311c0453c53c84bb983b62728e9bc0b1cc82faae4cad40dd2e817fe2894R9-R14) [[2]](diffhunk://#diff-f6787311c0453c53c84bb983b62728e9bc0b1cc82faae4cad40dd2e817fe2894L43-R44) [app/anime/[id].tsxL535-R536](diffhunk://#diff-61e97279484fa6823ed772cef5c221ee5386705e7808ef92a311f0c2ad56769dL535-R536), [app/manga/[id].tsxL459-R460](diffhunk://#diff-ceb88e753a1650781f98e78e03eff88d3f329189f07c4e2dfe61bb66c0ddd9f4L459-R460))

**Project Configuration and Scripts:**

* Bumped app version to `0.2.1` in both `package.json` and `app.json` to reflect the new release. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4) [[2]](diffhunk://#diff-96677aa35debfefd031d9d34d9c70369754ee3acb2d9a9d4090e98612efee6f5L5-R5)
* Added a post-install script to automatically run GraphQL code generation after EAS build installs.

**Bug Fixes:**

* Fixed a logging message in the manga detail screen to correctly reference "manga data" instead of "anime data". ([app/manga/[id].tsxL153-R153](diffhunk://#diff-ceb88e753a1650781f98e78e03eff88d3f329189f07c4e2dfe61bb66c0ddd9f4L153-R153))

* Fixed RelationCard component not working for `ANIME` type