### PR TITLE
Enhance user library management with GraphQL and UI improvements

### DIFF
--- a/app/(tabs)/library.tsx
+++ b/app/(tabs)/library.tsx
@@ -1,9 +1,187 @@
-import { Text, View } from "react-native";
+import { FlashList } from "@shopify/flash-list";
+import { Search } from "lucide-react-native";
+import { useMemo, useState } from "react";
+import { ActivityIndicator, Pressable, Text, TextInput, View } from "react-native";
+
+import LibraryMediaCard from "@/components/LibraryMediaCard";
+import { MediaType } from "@/lib/graphql/generated/graphql";
+import { useAuthStore } from "@/stores/authStore";
+
+type FlatLibraryItem = { type: "header"; name: string } | { type: "card"; entry: any };
 
 const Library = () => {
+   const { userAnimeLibraryLists, userMangaLibraryLists, userProfile } = useAuthStore();
+
+   // Local UI State
+   const [activeType, setActiveType] = useState<MediaType>(MediaType.Anime);
+   const [statusFilter, setStatusFilter] = useState("ALL");
+   const [searchQuery, setSearchQuery] = useState("");
+
+   // Dynamic Sections from User Profile
+   const dynamicSections = useMemo(() => {
+      const order =
+         (activeType === MediaType.Anime
+            ? userProfile?.mediaListOptions?.animeList?.sectionOrder
+            : userProfile?.mediaListOptions?.mangaList?.sectionOrder) ?? [];
+
+      // Filter out empty strings and ensure "ALL" is always at the start
+      return ["ALL", ...order.filter((name): name is string => Boolean(name && name.length > 0))];
+   }, [userProfile, activeType]);
+
+   // Compute Filtered & Flattened Data
+   const flattenedData = useMemo(() => {
+      const isAnime = activeType === MediaType.Anime;
+      const sourceLists = isAnime ? userAnimeLibraryLists : userMangaLibraryLists;
+
+      // Pull order directly from the dynamic list (excluding "ALL")
+      const order = dynamicSections.filter((s) => s !== "ALL");
+
+      if (!sourceLists) return [];
+
+      const result: FlatLibraryItem[] = [];
+
+      order.forEach((sectionName) => {
+         // Filter: Only show the selected section if filter is not "ALL"
+         if (statusFilter !== "ALL" && sectionName !== statusFilter) return;
+
+         const currentList = sourceLists.find((l) => l?.name === sectionName);
+         if (!currentList?.entries) return;
+
+         // Search Filter
+         const filteredEntries = currentList.entries.filter((entry) => {
+            const title = (
+               entry?.media?.title?.english ??
+               entry?.media?.title?.romaji ??
+               ""
+            ).toLowerCase();
+            return title.includes(searchQuery.toLowerCase());
+         });
+
+         if (filteredEntries.length > 0) {
+            result.push({ type: "header", name: sectionName });
+
+            // Alpha Sort
+            const sortedEntries = [...filteredEntries].sort((a, b) => {
+               const titleA = a?.media?.title?.english || a?.media?.title?.romaji || "";
+               const titleB = b?.media?.title?.english || b?.media?.title?.romaji || "";
+               return titleA.localeCompare(titleB);
+            });
+
+            sortedEntries.forEach((entry) => {
+               result.push({ type: "card", entry });
+            });
+         }
+      });
+
+      return result;
+   }, [
+      userAnimeLibraryLists,
+      userMangaLibraryLists,
+      dynamicSections,
+      activeType,
+      statusFilter,
+      searchQuery,
+   ]);
+
+   if (!userAnimeLibraryLists || !userMangaLibraryLists) {
+      return (
+         <View className="flex-1 items-center justify-center">
+            <ActivityIndicator size="large" color="#fff" />
+         </View>
+      );
+   }
+
    return (
-      <View className="flex min-h-screen items-center justify-center">
-         <Text className="text-xl font-semibold text-white">Library Feature Coming Soon</Text>
+      <View className="w-full flex-1">
+         {/* --- SEARCH & TOGGLE --- */}
+         <View className="mt-2 flex-row items-center gap-2">
+            <View className="flex-1 flex-row items-center rounded-md bg-slate-900/70 px-4 py-2">
+               <Search color="#94a3b8" size={18} />
+               <TextInput
+                  placeholder={`Search in ${activeType.toLowerCase()} list...`}
+                  placeholderTextColor="#64748b"
+                  className="ml-2 flex-1 text-base text-white"
+                  value={searchQuery}
+                  onChangeText={setSearchQuery}
+               />
+            </View>
+
+            <Pressable
+               onPress={() => {
+                  setActiveType((prev) =>
+                     prev === MediaType.Anime ? MediaType.Manga : MediaType.Anime,
+                  );
+                  setStatusFilter("ALL");
+               }}
+               className="rounded-md bg-accent px-4 py-3 active:bg-accent-dark"
+            >
+               <Text className="text-[10px] font-black text-white">
+                  {activeType === MediaType.Anime ? "MANGA" : "ANIME"}
+               </Text>
+            </Pressable>
+         </View>
+
+         <View className="mt-4" style={{ height: 40 }}>
+            <FlashList
+               data={dynamicSections}
+               horizontal
+               showsHorizontalScrollIndicator={false}
+               renderItem={({ item }) => (
+                  <Pressable
+                     onPress={() => setStatusFilter(item)}
+                     className={`mr-2 rounded-full px-5 py-2 ${statusFilter === item ? "bg-white" : "bg-slate-800"}`}
+                  >
+                     <Text
+                        className={`text-center text-xs font-bold uppercase ${statusFilter === item ? "text-black" : "text-gray-400"}`}
+                     >
+                        {item}
+                     </Text>
+                  </Pressable>
+               )}
+            />
+         </View>
+
+         <View className="mt-2 flex-1">
+            <FlashList
+               data={flattenedData}
+               keyExtractor={(item, index) =>
+                  item.type === "header" ? `h-${item.name}` : `c-${item.entry.media.id}-${index}`
+               }
+               getItemType={(item) => item.type}
+               showsVerticalScrollIndicator={false}
+               contentContainerStyle={{ paddingBottom: 100 }}
+               renderItem={({ item }) => {
+                  if (item.type === "header") {
+                     return (
+                        <Text className="mb-4 mt-8 px-2 text-2xl font-bold text-text-primary">
+                           {item.name}
+                        </Text>
+                     );
+                  }
+                  const { media, progress, status } = item.entry;
+                  return (
+                     <LibraryMediaCard
+                        id={media?.id}
+                        title={media?.title?.english ?? media?.title?.romaji}
+                        image={media?.coverImage?.large}
+                        episodes={media?.episodes}
+                        chapters={media?.chapters}
+                        format={media?.format}
+                        type={media?.type}
+                        progress={progress}
+                        status={status}
+                        nextAiringAt={media?.nextAiringEpisode?.airingAt}
+                        nextAiringEpisode={media?.nextAiringEpisode?.episode}
+                     />
+                  );
+               }}
+               ListEmptyComponent={() => (
+                  <View className="mt-20 items-center">
+                     <Text className="text-gray-500">No results found in this section.</Text>
+                  </View>
+               )}
+            />
+         </View>
       </View>
    );
 };

--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -110,25 +110,21 @@ const SearchScreen = () => {
 
    return (
       <View className="w-full flex-1">
-         <View className="mt-2 flex-row items-center justify-between rounded-md bg-slate-900/70 px-4 py-2">
-            <View className="flex-1 flex-row items-center">
-               <Search color="white" size={20} />
+         <View className="mt-2 flex-row items-center gap-2">
+            <View className="flex-1 flex-row items-center rounded-md bg-slate-900/70 px-4 py-2">
+               <Search color="#94a3b8" size={18} />
                <TextInput
-                  className="ml-2 flex-1 text-xl text-white"
                   placeholder={searchPlaceholderText}
+                  placeholderTextColor="#64748b"
+                  className="ml-2 flex-1 text-base text-white"
                   value={searchQuery}
                   onChangeText={handleSearchChange}
-                  autoFocus={true}
-                  clearButtonMode="while-editing"
                />
             </View>
 
-            <Pressable
-               onPress={toggleMediaType}
-               className="ml-2 rounded-md bg-primary/70 px-3 py-1.5"
-            >
-               <Text className="text-[10px] font-semibold text-white">
-                  SWITCH TO {nextMediaType}
+            <Pressable onPress={toggleMediaType} className="rounded-md bg-accent px-4 py-3">
+               <Text className="text-xs font-black text-white">
+                  {nextMediaType === MediaType.Anime ? "ANIME" : "MANGA"}
                </Text>
             </Pressable>
          </View>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -11,18 +11,21 @@ import { Provider } from "urql";
 
 import { theme } from "@/constants/theme";
 import { client } from "@/lib/graphql/client";
-import type {
-   GetAuthUserDataQuery as GetAuthUserDataQueryData,
-   GetPopularAnimeQuery as GetPopularAnimeQueryData,
-   GetTrendingAnimeQuery as GetTrendingAnimeQueryData,
-   GetTrendingMangaQuery as GetTrendingMangaQueryData,
+import {
+   type GetAuthUserDataQuery as GetAuthUserDataQueryData,
+   type GetPopularAnimeQuery as GetPopularAnimeQueryData,
+   type GetTrendingAnimeQuery as GetTrendingAnimeQueryData,
+   type GetTrendingMangaQuery as GetTrendingMangaQueryData,
+   MediaType,
 } from "@/lib/graphql/generated/graphql";
 import { GetAuthUserDataQuery } from "@/lib/graphql/queries/getAuthUserData";
 import { GetPopularAnimeQuery } from "@/lib/graphql/queries/getPopularAnime";
 import { GetTrendingAnimeQuery } from "@/lib/graphql/queries/getTrendingAnime";
 import { GetTrendingMangaQuery } from "@/lib/graphql/queries/getTrendingManga";
+import { GetUserLibraryQuery } from "@/lib/graphql/queries/getUserLibrary";
 import { useAuthStore } from "@/stores/authStore";
 import { useDataStore } from "@/stores/dataStore";
+import { UserLibraryLists } from "@/types";
 
 void SplashScreen.preventAutoHideAsync();
 
@@ -55,13 +58,21 @@ export default function RootLayout() {
          Image.prefetch(urls);
       };
 
+      const preloadUserLibraryImages = (lists: UserLibraryLists) => {
+         const urls = lists
+            .flatMap((list) => list?.entries)
+            .map((entry) => entry?.media?.coverImage?.large)
+            .filter(isString);
+         Image.prefetch(urls);
+      };
+
       if (!useAuthStore.getState().isLoggedIn) {
          return;
       }
 
       const { setTrendingAnime, setPopularAnime, setTrendingManga } = useDataStore.getState();
 
-      const { setUserProfile } = useAuthStore.getState();
+      const { setUserProfile, setUserLibraryLists } = useAuthStore.getState();
 
       const [trendingAnimeResult, popularAnimeResult, trendingMangaResult, userProfileResult] =
          await Promise.all([
@@ -70,6 +81,8 @@ export default function RootLayout() {
             client.query(GetTrendingMangaQuery, {}, { requestPolicy: "network-only" }).toPromise(),
             client.query(GetAuthUserDataQuery, {}, { requestPolicy: "network-only" }).toPromise(),
          ]);
+
+      let userLibraryResult = null;
 
       if (!useAuthStore.getState().isLoggedIn) {
          return;
@@ -93,6 +106,22 @@ export default function RootLayout() {
       if (userProfileResult.data?.Viewer) {
          setUserProfile(userProfileResult.data.Viewer);
          preloadUserProfileImages(userProfileResult.data.Viewer);
+
+         userLibraryResult = await client
+            .query(
+               GetUserLibraryQuery,
+               { userId: userProfileResult.data.Viewer.id, type: MediaType.Anime },
+               { requestPolicy: "network-only" },
+            )
+            .toPromise();
+      }
+
+      if (
+         userLibraryResult?.data?.MediaListCollection?.lists &&
+         userLibraryResult?.data?.MediaListCollection?.lists.length > 0
+      ) {
+         setUserLibraryLists(userLibraryResult?.data?.MediaListCollection?.lists);
+         preloadUserLibraryImages(userLibraryResult?.data?.MediaListCollection?.lists);
       }
    };
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -72,7 +72,8 @@ export default function RootLayout() {
 
       const { setTrendingAnime, setPopularAnime, setTrendingManga } = useDataStore.getState();
 
-      const { setUserProfile, setUserLibraryLists } = useAuthStore.getState();
+      const { setUserProfile, setUserAnimeLibraryLists, setUserMangaLibraryLists } =
+         useAuthStore.getState();
 
       const [trendingAnimeResult, popularAnimeResult, trendingMangaResult, userProfileResult] =
          await Promise.all([
@@ -82,7 +83,8 @@ export default function RootLayout() {
             client.query(GetAuthUserDataQuery, {}, { requestPolicy: "network-only" }).toPromise(),
          ]);
 
-      let userLibraryResult = null;
+      let userAnimeLibraryResult = null;
+      let userMangaLibraryResult = null;
 
       if (!useAuthStore.getState().isLoggedIn) {
          return;
@@ -107,21 +109,37 @@ export default function RootLayout() {
          setUserProfile(userProfileResult.data.Viewer);
          preloadUserProfileImages(userProfileResult.data.Viewer);
 
-         userLibraryResult = await client
+         userAnimeLibraryResult = await client
             .query(
                GetUserLibraryQuery,
                { userId: userProfileResult.data.Viewer.id, type: MediaType.Anime },
                { requestPolicy: "network-only" },
             )
             .toPromise();
+
+         userMangaLibraryResult = await client
+            .query(
+               GetUserLibraryQuery,
+               { userId: userProfileResult.data.Viewer.id, type: MediaType.Manga },
+               { requestPolicy: "network-only" },
+            )
+            .toPromise();
       }
 
       if (
-         userLibraryResult?.data?.MediaListCollection?.lists &&
-         userLibraryResult?.data?.MediaListCollection?.lists.length > 0
+         userAnimeLibraryResult?.data?.MediaListCollection?.lists &&
+         userAnimeLibraryResult?.data?.MediaListCollection?.lists.length > 0
       ) {
-         setUserLibraryLists(userLibraryResult?.data?.MediaListCollection?.lists);
-         preloadUserLibraryImages(userLibraryResult?.data?.MediaListCollection?.lists);
+         setUserAnimeLibraryLists(userAnimeLibraryResult?.data?.MediaListCollection?.lists);
+         preloadUserLibraryImages(userAnimeLibraryResult?.data?.MediaListCollection?.lists);
+      }
+
+      if (
+         userMangaLibraryResult?.data?.MediaListCollection?.lists &&
+         userMangaLibraryResult?.data?.MediaListCollection?.lists.length > 0
+      ) {
+         setUserMangaLibraryLists(userMangaLibraryResult?.data?.MediaListCollection?.lists);
+         preloadUserLibraryImages(userMangaLibraryResult?.data?.MediaListCollection?.lists);
       }
    };
 

--- a/components/LibraryMediaCard.tsx
+++ b/components/LibraryMediaCard.tsx
@@ -1,0 +1,116 @@
+import { Image } from "expo-image";
+import { useRouter } from "expo-router";
+import { Pressable, Text, View } from "react-native";
+
+import { formatAiringDate } from "@/lib/utils/date";
+
+interface LibraryMediaCardProps {
+   id: number | null | undefined;
+   title: string | null | undefined;
+   image: string | null | undefined;
+   episodes?: number | null | undefined;
+   chapters?: number | null | undefined;
+   format: string | null | undefined;
+   type: string | null | undefined;
+   progress: number | null | undefined;
+   status: string | null | undefined;
+   nextAiringEpisode?: number | null | undefined;
+   nextAiringAt?: number | null | undefined;
+}
+
+const LibraryMediaCard = ({
+   id,
+   title,
+   image,
+   episodes,
+   chapters,
+   format,
+   type,
+   progress,
+   status,
+   nextAiringAt,
+   nextAiringEpisode,
+}: LibraryMediaCardProps) => {
+   const router = useRouter();
+
+   // 1. Calculate Progress Percentage
+   const totalCount = episodes ?? chapters ?? 0;
+   const currentProgress = progress ?? 0;
+   const progressPercentage = totalCount > 0 ? (currentProgress / totalCount) * 100 : 0;
+
+   const handleOnPress = () => {
+      if (type === "ANIME") {
+         router.push(`/anime/${id}`);
+      } else if (type === "MANGA") {
+         router.push(`/manga/${id}`);
+      }
+   };
+
+   return (
+      <Pressable
+         onPress={handleOnPress}
+         className="mb-4 flex-row overflow-hidden rounded-md bg-[#11212D]/70"
+      >
+         {image ? (
+            <Image
+               source={{ uri: image }}
+               style={{
+                  width: 100,
+                  height: 140,
+                  borderTopLeftRadius: 6,
+                  borderBottomLeftRadius: 6,
+               }}
+               contentFit="cover"
+               cachePolicy="disk"
+               transition={200}
+               recyclingKey={id?.toString()}
+            />
+         ) : (
+            <View className="h-[140] w-[100] rounded-l-md bg-slate-800" />
+         )}
+
+         <View className="min-w-0 flex-1 justify-between px-4 py-2">
+            <View className="flex gap-3">
+               <Text className="text-[16px] font-medium text-white" numberOfLines={2}>
+                  {title ?? "Title Unavailable"}
+               </Text>
+               <View className="flex-row items-center gap-2">
+                  <Text className="text-[13px] text-white">{format?.split("_").join(" ")}</Text>
+                  {nextAiringAt && <Text className="text-accent-light">●</Text>}
+                  {nextAiringAt && (
+                     <Text className="text-sm text-accent-light">
+                        EP {nextAiringEpisode} on {formatAiringDate(nextAiringAt)}
+                     </Text>
+                  )}
+               </View>
+               {typeof nextAiringEpisode === "number" &&
+               typeof progress === "number" &&
+               progress < nextAiringEpisode - 1 ? (
+                  <Text className="text-sm font-semibold text-accent-light">
+                     {nextAiringEpisode - progress - 1} EP BEHIND
+                  </Text>
+               ) : (
+                  <Text></Text>
+               )}
+            </View>
+
+            <View className="flex gap-2 px-2">
+               <View className="flex-row items-end justify-between">
+                  <Text></Text>
+                  <Text className="text-sm text-text-secondary">
+                     {progress} / {episodes ?? chapters ?? "?"}
+                  </Text>
+               </View>
+            </View>
+            <View className="h-1.5 w-full overflow-hidden rounded-full bg-slate-800">
+               <View
+                  className="h-full bg-accent"
+                  style={{ width: `${Math.min(progressPercentage, 100)}%` }}
+               />
+            </View>
+         </View>
+      </Pressable>
+   );
+};
+
+export default LibraryMediaCard;

--- a/hooks/useGetUserLibrary.ts
+++ b/hooks/useGetUserLibrary.ts
@@ -1,0 +1,22 @@
+import { useState } from "react";
+import { useQuery } from "urql";
+
+import { MediaType } from "@/lib/graphql/generated/graphql";
+import { GetUserLibraryQuery } from "@/lib/graphql/queries/getUserLibrary";
+
+export const useGetUserLibrary = (userId: number | null) => {
+   const [type, setType] = useState<MediaType>(MediaType.Anime);
+
+   const [result] = useQuery({
+      query: GetUserLibraryQuery,
+      variables: {
+         type,
+         userId,
+      },
+      pause: userId === null,
+   });
+
+   const { data, fetching, error } = result;
+
+   return { data, fetching, error, setType, type };
+};

--- a/hooks/useGetUserLibrary.ts
+++ b/hooks/useGetUserLibrary.ts
@@ -1,22 +1,79 @@
-import { useState } from "react";
+import { useEffect } from "react";
 import { useQuery } from "urql";
 
 import { MediaType } from "@/lib/graphql/generated/graphql";
 import { GetUserLibraryQuery } from "@/lib/graphql/queries/getUserLibrary";
+import { useAuthStore } from "@/stores/authStore";
 
-export const useGetUserLibrary = (userId: number | null) => {
-   const [type, setType] = useState<MediaType>(MediaType.Anime);
+export const useGetUserLibrary = () => {
+   const {
+      userProfile,
+      userAnimeLibraryLists,
+      setUserAnimeLibraryLists,
+      userMangaLibraryLists,
+      setUserMangaLibraryLists,
+   } = useAuthStore();
 
-   const [result] = useQuery({
+   const [animeLibraryResult] = useQuery({
       query: GetUserLibraryQuery,
       variables: {
-         type,
-         userId,
+         type: MediaType.Anime,
+         userId: userProfile?.id ?? null,
       },
-      pause: userId === null,
+      requestPolicy: "cache-and-network",
    });
 
-   const { data, fetching, error } = result;
+   const {
+      data: animeLibraryData,
+      fetching: animeLibraryFetching,
+      error: animeLibraryError,
+   } = animeLibraryResult;
 
-   return { data, fetching, error, setType, type };
+   const [mangaLibraryResult] = useQuery({
+      query: GetUserLibraryQuery,
+      variables: {
+         type: MediaType.Manga,
+         userId: userProfile?.id ?? null,
+      },
+      requestPolicy: "cache-and-network",
+   });
+
+   const {
+      data: mangaLibraryData,
+      fetching: mangaLibraryFetching,
+      error: mangaLibraryError,
+   } = mangaLibraryResult;
+
+   useEffect(() => {
+      if (!userAnimeLibraryLists) {
+         if ((animeLibraryData?.MediaListCollection?.lists ?? []).length === 0) return;
+
+         setUserAnimeLibraryLists(animeLibraryData?.MediaListCollection?.lists!);
+      }
+   }, [
+      animeLibraryData?.MediaListCollection?.lists,
+      setUserAnimeLibraryLists,
+      userAnimeLibraryLists,
+   ]);
+
+   useEffect(() => {
+      if (!userMangaLibraryLists) {
+         if ((mangaLibraryData?.MediaListCollection?.lists ?? []).length === 0) return;
+
+         setUserMangaLibraryLists(mangaLibraryData?.MediaListCollection?.lists!);
+      }
+   }, [
+      mangaLibraryData?.MediaListCollection?.lists,
+      setUserMangaLibraryLists,
+      userMangaLibraryLists,
+   ]);
+
+   return {
+      userAnimeLibraryLists,
+      animeLibraryFetching,
+      animeLibraryError,
+      userMangaLibraryLists,
+      mangaLibraryFetching,
+      mangaLibraryError,
+   };
 };

--- a/lib/graphql/queries/getAuthUserData.ts
+++ b/lib/graphql/queries/getAuthUserData.ts
@@ -77,6 +77,18 @@ export const GetAuthUserDataQuery = gql(/* GraphQL */ `
                }
             }
          }
+         mediaListOptions {
+            animeList {
+               customLists
+               sectionOrder
+            }
+            mangaList {
+               customLists
+               sectionOrder
+            }
+            rowOrder
+            scoreFormat
+         }
       }
    }
 `);

--- a/lib/graphql/queries/getUserLibrary.ts
+++ b/lib/graphql/queries/getUserLibrary.ts
@@ -21,6 +21,7 @@ export const GetUserLibraryQuery = gql(/* GraphQL */ `
                   episodes
                   chapters
                   format
+                  type
                   nextAiringEpisode {
                      episode
                      airingAt

--- a/lib/graphql/queries/getUserLibrary.ts
+++ b/lib/graphql/queries/getUserLibrary.ts
@@ -1,0 +1,33 @@
+import { gql } from "@/lib/graphql/generated";
+
+export const GetUserLibraryQuery = gql(/* GraphQL */ `
+   query GetUserLibraryQuery($type: MediaType, $userId: Int) {
+      MediaListCollection(type: $type, userId: $userId) {
+         lists {
+            name
+            status
+            entries {
+               status
+               progress
+               media {
+                  id
+                  title {
+                     english
+                     romaji
+                  }
+                  coverImage {
+                     large
+                  }
+                  episodes
+                  chapters
+                  format
+                  nextAiringEpisode {
+                     episode
+                     airingAt
+                  }
+               }
+            }
+         }
+      }
+   }
+`);

--- a/stores/authStore.ts
+++ b/stores/authStore.ts
@@ -1,18 +1,18 @@
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
-import type { GetAuthUserDataQuery } from "@/lib/graphql/generated/graphql";
 import { storage } from "@/lib/storage/mmkv";
-
-type UserProfile = NonNullable<GetAuthUserDataQuery["Viewer"]>;
+import { UserLibraryLists, UserProfile } from "@/types";
 
 interface AuthState {
    token: string | null;
    expiresAt: number | null;
    userProfile: UserProfile | null;
+   userLibraryLists: UserLibraryLists | null;
    isLoggedIn: boolean;
    setToken: (token: string, expiresAt: number) => void;
    setUserProfile: (data: UserProfile) => void;
+   setUserLibraryLists: (lists: UserLibraryLists) => void;
    logout: () => void;
 }
 
@@ -29,6 +29,7 @@ export const useAuthStore = create<AuthState>()(
          token: null,
          expiresAt: null,
          userProfile: null,
+         userLibraryLists: null,
          isLoggedIn: false,
 
          setToken: (token, expiresAt) => {
@@ -37,6 +38,8 @@ export const useAuthStore = create<AuthState>()(
          },
 
          setUserProfile: (data) => set({ userProfile: data }),
+
+         setUserLibraryLists: (lists) => set({ userLibraryLists: lists }),
 
          logout: () => {
             set({ token: null, expiresAt: null, isLoggedIn: false, userProfile: null });

--- a/stores/authStore.ts
+++ b/stores/authStore.ts
@@ -8,11 +8,13 @@ interface AuthState {
    token: string | null;
    expiresAt: number | null;
    userProfile: UserProfile | null;
-   userLibraryLists: UserLibraryLists | null;
+   userAnimeLibraryLists: UserLibraryLists | null;
+   userMangaLibraryLists: UserLibraryLists | null;
    isLoggedIn: boolean;
    setToken: (token: string, expiresAt: number) => void;
    setUserProfile: (data: UserProfile) => void;
-   setUserLibraryLists: (lists: UserLibraryLists) => void;
+   setUserAnimeLibraryLists: (lists: UserLibraryLists) => void;
+   setUserMangaLibraryLists: (lists: UserLibraryLists) => void;
    logout: () => void;
 }
 
@@ -29,7 +31,8 @@ export const useAuthStore = create<AuthState>()(
          token: null,
          expiresAt: null,
          userProfile: null,
-         userLibraryLists: null,
+         userAnimeLibraryLists: null,
+         userMangaLibraryLists: null,
          isLoggedIn: false,
 
          setToken: (token, expiresAt) => {
@@ -39,7 +42,8 @@ export const useAuthStore = create<AuthState>()(
 
          setUserProfile: (data) => set({ userProfile: data }),
 
-         setUserLibraryLists: (lists) => set({ userLibraryLists: lists }),
+         setUserAnimeLibraryLists: (lists) => set({ userAnimeLibraryLists: lists }),
+         setUserMangaLibraryLists: (lists) => set({ userMangaLibraryLists: lists }),
 
          logout: () => {
             set({ token: null, expiresAt: null, isLoggedIn: false, userProfile: null });

--- a/types/index.ts
+++ b/types/index.ts
@@ -3,6 +3,7 @@ import type {
    GetAuthUserDataQuery as GetAuthUserData,
    GetMangaByIdQuery as GetMangaByIdQueryData,
    GetMediaCharactersQuery as GetMediaCharactersData,
+   GetUserLibraryQueryQuery as GetUserLibraryData,
 } from "@/lib/graphql/generated/graphql";
 
 export type CharacterEdge = NonNullable<
@@ -17,3 +18,7 @@ export type MangaMedia = NonNullable<GetMangaByIdQueryData["Media"]>;
 export type SharedMedia = MangaMedia | AnimeMedia;
 
 export type UserProfile = NonNullable<GetAuthUserData["Viewer"]>;
+
+export type UserLibraryLists = NonNullable<
+   NonNullable<GetUserLibraryData["MediaListCollection"]>["lists"]
+>;


### PR DESCRIPTION
# Pull Request

## Summary

This pull request implements the user library feature, allowing users to view and interact with their anime and manga lists. It introduces new data fetching logic, updates the UI to display the user's library with sections and search/filter capabilities, and adds a reusable media card component. Additionally, it updates the authentication store to persist library data and improves query and image preloading logic.

**User Library Feature Implementation**

* Added a new `LibraryMediaCard` component for displaying media entries in the user's library, including progress, next airing episode info, and navigation to detail pages.
* Created the `useGetUserLibrary` hook and the `GetUserLibraryQuery` GraphQL query to fetch and manage the user's anime and manga library lists. [[1]](diffhunk://#diff-07047724e9334685c3576ce1f1983cb3a4ca920db5a51a05fa70ab743cae7e15R1-R79) [[2]](diffhunk://#diff-552228f6a2ba565a783e21ce3cb05787bba54305669c8e0b672b250844c1afa3R1-R34)
* Updated the authentication store (`authStore`) to persist `userAnimeLibraryLists` and `userMangaLibraryLists`, along with setters for these lists. [[1]](diffhunk://#diff-b88eb57d62895ac0c3fd6e0dbfcf52ee8a500542abba37d8f6a3581f31b56febL4-R17) [[2]](diffhunk://#diff-b88eb57d62895ac0c3fd6e0dbfcf52ee8a500542abba37d8f6a3581f31b56febR34-R35) [[3]](diffhunk://#diff-b88eb57d62895ac0c3fd6e0dbfcf52ee8a500542abba37d8f6a3581f31b56febR45-R47)

**UI/UX Enhancements for Library and Search**

* Overhauled the `Library` screen (`library.tsx`) to show the user's library with section toggles, search, and filtering by status, using the new `LibraryMediaCard` and `FlashList` for performance.
* Improved the search bar and toggle button UI in both the library and search screens for consistency and better user experience.

**Data Fetching and Preloading Improvements**

* Modified the root layout to fetch user library lists on login, preload cover images for smoother UI, and store the lists in the auth store. [[1]](diffhunk://#diff-a297596ca5a79abd3db7509592a07106f1c27c02ee55895a4dee8bcce9f7da57L14-R28) [[2]](diffhunk://#diff-a297596ca5a79abd3db7509592a07106f1c27c02ee55895a4dee8bcce9f7da57R61-R76) [[3]](diffhunk://#diff-a297596ca5a79abd3db7509592a07106f1c27c02ee55895a4dee8bcce9f7da57R86-R88) [[4]](diffhunk://#diff-a297596ca5a79abd3db7509592a07106f1c27c02ee55895a4dee8bcce9f7da57R111-R142)

**GraphQL Query Enhancements**

* Updated the user profile query to include `mediaListOptions` (such as section order and custom lists) for dynamic section rendering in the library.

---

**References:**  
[[1]](diffhunk://#diff-6a60160342f5e0a9ff6a75862541bd3ed5a0445f4aa9251241791dce3926a106R1-R116) [[2]](diffhunk://#diff-07047724e9334685c3576ce1f1983cb3a4ca920db5a51a05fa70ab743cae7e15R1-R79) [[3]](diffhunk://#diff-552228f6a2ba565a783e21ce3cb05787bba54305669c8e0b672b250844c1afa3R1-R34) [[4]](diffhunk://#diff-b88eb57d62895ac0c3fd6e0dbfcf52ee8a500542abba37d8f6a3581f31b56febL4-R17) [[5]](diffhunk://#diff-b88eb57d62895ac0c3fd6e0dbfcf52ee8a500542abba37d8f6a3581f31b56febR34-R35) [[6]](diffhunk://#diff-b88eb57d62895ac0c3fd6e0dbfcf52ee8a500542abba37d8f6a3581f31b56febR45-R47) [[7]](diffhunk://#diff-05514a7b4f7cc475b4a0432c61c92525964d293e798f5b2b0ce9d0e52f43b102L1-R184) [[8]](diffhunk://#diff-d08f3abc80ef52d1acff6e4438664ab6ccc7f1889bb66dbe438929e6d11b0cf3L113-R127) [[9]](diffhunk://#diff-a297596ca5a79abd3db7509592a07106f1c27c02ee55895a4dee8bcce9f7da57L14-R28) [[10]](diffhunk://#diff-a297596ca5a79abd3db7509592a07106f1c27c02ee55895a4dee8bcce9f7da57R61-R76) [[11]](diffhunk://#diff-a297596ca5a79abd3db7509592a07106f1c27c02ee55895a4dee8bcce9f7da57R86-R88) [[12]](diffhunk://#diff-a297596ca5a79abd3db7509592a07106f1c27c02ee55895a4dee8bcce9f7da57R111-R142) [[13]](diffhunk://#diff-88317377bb039a75cf5c643b0706af2ff5bd78de1de80c99d720e4e8d8aeefcbR80-R91)

## Issue Closes

<!-- Add issue references here, for example: Closes #123. -->

Closes: #4 
Closes: #5 

## Type of Change

<!-- Delete any items that do not apply. -->

- [ ] Bug fix
- [x] New feature
- [x] UI / UX change
- [x] Refactor
- [x] Performance improvement
- [ ] Dependency or tooling update
- [ ] Documentation update

## Testing

<!-- Describe the exact checks you ran. Include device or emulator details when relevant. -->

- [x] `npm run lint`
- [x] `npm run format`
- [x] `npm run codegen`
- [x] Manual testing on Android
- [ ] Other:


## Checklist

- [ ] I verified the UI on the relevant screen sizes.
- [x] I checked that GraphQL types were regenerated if queries or mutations changed.
- [ ] I kept the change scoped to this PR.
- [x] I confirmed linting and formatting pass.
